### PR TITLE
changed where the user has to hover on the event widget for the curso…

### DIFF
--- a/styles/eventWidgetStyles.css
+++ b/styles/eventWidgetStyles.css
@@ -2,7 +2,6 @@
     border-radius: 5px;
     padding: 5px;
     margin: 5px;
-    cursor: pointer;
     display: flex;
     justify-content: space-between;
 }
@@ -13,6 +12,7 @@
 
 .event p {
     margin :0;
+    cursor: pointer;
 
 }
 


### PR DESCRIPTION
changed where the user has to hover on the event widget for the cursor to turn into a pointer

1. check that the cursor only turns into a pointer when the cursor hovers over the actual text in an event listing, not the entire green event box.