### PR TITLE
refactored chatWidget hide button to show on mouseover instead of click

### DIFF
--- a/scripts/chatWidget/chatEventListener.js
+++ b/scripts/chatWidget/chatEventListener.js
@@ -123,15 +123,32 @@ const createChatListener = (chatWidget) => {
         }
     })
     
-    // create a click event to display an edit button on each message
-    chatContainerEl.addEventListener("click", event => {
-        // check if the target has a next sibling
-        if (event.target.nextElementSibling) {
-            // check if the next sibling element is the Edit Button
-            let nextSiblingId = event.target.nextElementSibling.id
-            if (nextSiblingId.startsWith("editBtn_")) {
-                // toggle class to make button visible
-                event.target.nextElementSibling.classList.toggle("hidden")
+    // detects if the user is hovering over one of their chat messages and displays an edit button
+    chatContainerEl.addEventListener("mouseover", event => {
+        // check if the target has the parent of the chat Widget message
+        if (event.target.parentElement.className.includes("chatWidget__msg")) {
+            // get the id number of the msg 
+            let msgId = event.target.parentElement.dataset.msgId
+            if (document.getElementById("editBtn_" + msgId)) {
+                // get control of the edit button that cooresponds with the message
+                let hideBtn = document.getElementById("editBtn_" + msgId)
+                // remove hidden class to make button visible
+                hideBtn.classList.remove("hidden")
+            }
+        }
+    })
+
+    // detects when the user has moved mouse out of a chat message
+    chatContainerEl.addEventListener("mouseout", event => {
+        // check if the target has the parent of the chat Widget message
+        if (event.target.parentElement.className.includes("chatWidget__msg")) {            
+            // get the id number of the msg 
+            let msgId = event.target.parentElement.dataset.msgId
+            if (document.getElementById("editBtn_" + msgId)) {
+                // get control of the edit button that cooresponds with the message
+                let hideBtn = document.getElementById("editBtn_" + msgId)
+                // add hidden class to make button invisible
+                hideBtn.classList.add("hidden")
             }
         }
     })

--- a/styles/chatWidget_styles.css
+++ b/styles/chatWidget_styles.css
@@ -77,7 +77,7 @@ p {
 .hidden {
     visibility: hidden;
     opacity: 0;
-    transition: visibility 0s linear 2s, opacity 300ms;
+    transition: visibility 0s linear 2s, opacity 700ms;
 }
 
 /* changes the width of the chat widget when viewport is less than 850 to match all the other widgets as they stack vertically. */


### PR DESCRIPTION
1. Check that when you hover over messages that you created, the edit button shows up and hides when your mouse leaves that particular chat message. 
1. also make sure the edit button shows up on private messages you create.

(I accidentally merged this in earlier, thinking I was in my forked repo. So I reverted, then realized that you can't create a new pull request after a revert. So I "reverted" my revert, and created this pull request. :) What a strange github system. )